### PR TITLE
Add support to exclude labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ All configuration values, except `GITHUB_TOKEN`, are optional.
 
 * `PR_LABELS`: Controls which labels _autoupdate_ will look for when monitoring PRs. Only used if `PR_FILTER="labelled"`. This can be either a single label or a comma-separated list of labels.
 
+* `EXCLUDED_LABELS`: Controls which labels _autoupdate_ will ignore for when monitoring PRs. This option works with all `PR_FILTER` options, and it will be evaluated after it. This can be either a single label or a comma-separated list of labels.
+
 * `MERGE_MSG`: A custom message to use when creating the merge commit from the destination branch to your pull request's branch.
 
 * `RETRY_COUNT`: The number of times a branch update should be attempted before _autoupdate_ gives up (default: `"5"`).

--- a/src/autoupdater.js
+++ b/src/autoupdater.js
@@ -195,6 +195,16 @@ class AutoUpdater {
       }
     }
 
+    const exclidedLabels = this.config.excludedLabels();
+    for (const label of pull.labels) {
+      if (exclidedLabels.includes(label.name)) {
+        ghCore.info(
+          `Pull request has excluded label '${label.name}', skipping update.`
+        );
+        return false;
+      }
+    }
+
     ghCore.info('All checks pass and PR branch is behind base branch.');
     return true;
   }

--- a/src/config-loader.js
+++ b/src/config-loader.js
@@ -22,6 +22,11 @@ class ConfigLoader {
     return rawLabels.split(',').map((label) => label.trim());
   }
 
+  excludedLabels() {
+    const rawLabels = this.getValue('EXCLUDED_LABELS', false,  '');
+    return rawLabels.split(',').map((label) => label.trim());
+  }
+  
   mergeMsg() {
     const msg = this.getValue(
       'MERGE_MSG',


### PR DESCRIPTION
This would work to exclude https://dependabot.com/ dependencies update, as the bot manages their own PRs