### PR TITLE
Add ability to ignore merge conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ All configuration values, except `GITHUB_TOKEN`, are optional.
 
 * `RETRY_SLEEP`: The amount of time (in milliseconds) that _autoupdate_ should wait between branch update attempts (default: `"300"`).
 
+* `MERGE_CONFLICT_ACTION`: Controls how _autoupdate_ handles a merge conflict when updating a PR. Possible values are:
+  * `"fail"` (default): _autoupdate_ will report a failure on each PR that has a merge conflict.
+  * `"ignore"`: _autoupdate_ will silently ignore merge conflicts.
+
 Here's an example workflow file with all of the above options specified:
 
 ```yaml

--- a/src/autoupdater.js
+++ b/src/autoupdater.js
@@ -236,8 +236,11 @@ class AutoUpdater {
       } catch (e) {
         if (e.message === "Merge conflict" && mergeConflictAction === "ignore") {
           return;
-        };
-        
+        } else if (e.message === "Merge conflict") {
+          ghCore.error("Merge conflict error trying to update branch");
+          throw e;
+        }
+
         ghCore.error(`Caught error trying to update branch: ${e.message}`);
 
         if (retries < retryCount) {

--- a/src/autoupdater.js
+++ b/src/autoupdater.js
@@ -235,6 +235,7 @@ class AutoUpdater {
         break;
       } catch (e) {
         if (e.message === "Merge conflict" && mergeConflictAction === "ignore") {
+          ghCore.info('Merge conflict detected, skipping update.');
           return;
         } else if (e.message === "Merge conflict") {
           ghCore.error("Merge conflict error trying to update branch");

--- a/src/autoupdater.js
+++ b/src/autoupdater.js
@@ -224,6 +224,8 @@ class AutoUpdater {
 
     const retryCount = this.config.retryCount();
     const retrySleep = this.config.retrySleep();
+    const mergeConflictAction = this.config.mergeConflictAction();
+    
     let retries = 0;
 
     while (true) {
@@ -232,6 +234,10 @@ class AutoUpdater {
         await doMerge();
         break;
       } catch (e) {
+        if (e.message === "Merge conflict" && mergeConflictAction === "ignore") {
+          return;
+        };
+        
         ghCore.error(`Caught error trying to update branch: ${e.message}`);
 
         if (retries < retryCount) {

--- a/src/config-loader.js
+++ b/src/config-loader.js
@@ -60,6 +60,11 @@ class ConfigLoader {
     ), 10);
   }
 
+  mergeConflictAction() {
+    // one of 'fail' or 'ignore'.
+    return this.getValue('MERGE_CONFLICT_ACTION', false,  'fail');
+  }
+
   getValue(key, required = false, defaulVal = null) {
     if (key in this.env
       && this.env[key] !== null


### PR DESCRIPTION
More actions could be added like "comment". But ignoring seems like a good start as the PR itself will get a merge conflict notification from github