### PR TITLE
Skip updating if upstream repo cannot be found

### DIFF
--- a/src/autoupdater.ts
+++ b/src/autoupdater.ts
@@ -141,6 +141,12 @@ export class AutoUpdater {
       );
       return false;
     }
+    if (!pull.head.repo) {
+      ghCore.warning(
+        `Skipping pull request, fork appears to have been deleted.`,
+      );
+      return false;
+    }
 
     const { data: comparison } = await this.octokit.repos.compareCommits({
       owner: pull.head.repo.owner.login,

--- a/test/autoupdate.test.ts
+++ b/test/autoupdate.test.ts
@@ -72,6 +72,19 @@ describe('test `prNeedsUpdate`', () => {
     expect(needsUpdate).toEqual(false);
   });
 
+  test('originating repo of pull request has been deleted', async () => {
+    const pull = Object.assign({}, validPull, {
+      head: {
+        label: head,
+        ref: head,
+        repo: null,
+      },
+    });
+    const updater = new AutoUpdater(config, {});
+    const needsUpdate = await updater.prNeedsUpdate(pull);
+    expect(needsUpdate).toEqual(false);
+  });
+
   test('pull request is not behind', async () => {
     const scope = nock('https://api.github.com:443')
       .get(`/repos/${owner}/${repo}/compare/${head}...${base}`)


### PR DESCRIPTION
First off, thank you for this tool! Autoupdate has been indispensable in our workflow. 🙇🏼 

We ran into a bit of an issue though, when one of our external contributors deleted their fork before their PR was merged. This led to autoupdate crashing while it's evaluating all opened PRs, and hence not updating any of the open PRs. According to this [doc](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/checking-out-pull-requests-locally#modifying-an-inactive-pull-request-locally), once the fork/head repo has been deleted, updating the PR branch will have to be done manually anyway, so I think we can just skip it if that's the case.  