### PR TITLE
Support workflow_run triggered by push event workflows

### DIFF
--- a/src/autoupdater.ts
+++ b/src/autoupdater.ts
@@ -58,22 +58,24 @@ export class AutoUpdater {
   async handleWorkflowRun(): Promise<number> {
     const { workflow_run, repository } = this.eventData;
     const branch = workflow_run.head_branch;
+    const event = workflow_run.event;
 
+    if (workflow_run.event !== 'push') {
+      ghCore.warning(
+        `Workflow_run event triggered via ${event} workflow not yet supported.`,
+      );
+      return 0;
+    }
+
+    // this may not be possible given the check above, but leaving in for now
     if (branch.length === 0) {
-      ghCore.warning('Push event was not on a branch, skipping.');
+      ghCore.warning('Event was not on a branch, skipping.');
       return 0;
     }
 
     ghCore.info(
-      `Handling workflow-run event triggered by '${workflow_run.event}' on '${branch}'`,
+      `Handling workflow-run event triggered by '${event}' on '${branch}'`,
     );
-
-    if (workflow_run.pull_requests.length !== 0) {
-      ghCore.warning(
-        'Workflow_run event triggered via pull_request workflow not yet supported.',
-      );
-      return 0;
-    }
 
     const updated = await this.pulls(`refs/heads/${branch}`, repository);
 

--- a/src/autoupdater.ts
+++ b/src/autoupdater.ts
@@ -3,6 +3,7 @@ import { GitHub } from '@actions/github/lib/utils';
 import * as ghCore from '@actions/core';
 import * as octokit from '@octokit/types';
 import { ConfigLoader } from './config-loader';
+import { PayloadRepository } from '@actions/github/lib/interfaces';
 
 interface MergeOpts {
   owner: string;
@@ -32,6 +33,54 @@ export class AutoUpdater {
 
     ghCore.info(`Handling push event on ref '${ref}'`);
 
+    const updated = await this.pulls(ref, repository);
+
+    return updated;
+  }
+
+  async handlePullRequest(): Promise<boolean> {
+    const { action } = this.eventData;
+
+    ghCore.info(`Handling pull_request event triggered by action '${action}'`);
+
+    const isUpdated = await this.update(this.eventData.pull_request);
+    if (isUpdated) {
+      ghCore.info(
+        'Auto update complete, pull request branch was updated with changes from the base branch.',
+      );
+    } else {
+      ghCore.info('Auto update complete, no changes were made.');
+    }
+
+    return isUpdated;
+  }
+
+  async handleWorkflowRun(): Promise<number> {
+    const { workflow_run, repository } = this.eventData;
+    const branch = workflow_run.head_branch;
+
+    if (branch.length === 0) {
+      ghCore.warning('Push event was not on a branch, skipping.');
+      return 0;
+    }
+
+    ghCore.info(
+      `Handling workflow-run event triggered by '${workflow_run.event}' on '${branch}'`,
+    );
+
+    if (workflow_run.pull_requests.length !== 0) {
+      ghCore.warning(
+        'Workflow_run event triggered via pull_request workflow not yet supported.',
+      );
+      return 0;
+    }
+
+    const updated = await this.pulls(`refs/heads/${branch}`, repository);
+
+    return updated;
+  }
+
+  async pulls(ref: string, repository: PayloadRepository): Promise<number> {
     if (!ref.startsWith('refs/heads/')) {
       ghCore.warning('Push event was not on a branch, skipping.');
       return 0;
@@ -41,7 +90,7 @@ export class AutoUpdater {
 
     let updated = 0;
     const paginatorOpts = this.octokit.pulls.list.endpoint.merge({
-      owner: repository.owner.name,
+      owner: repository.owner.name || repository.owner.login,
       repo: repository.name,
       base: baseBranch,
       state: 'open',
@@ -68,23 +117,6 @@ export class AutoUpdater {
     );
 
     return updated;
-  }
-
-  async handlePullRequest(): Promise<boolean> {
-    const { action } = this.eventData;
-
-    ghCore.info(`Handling pull_request event triggered by action '${action}'`);
-
-    const isUpdated = await this.update(this.eventData.pull_request);
-    if (isUpdated) {
-      ghCore.info(
-        'Auto update complete, pull request branch was updated with changes from the base branch.',
-      );
-    } else {
-      ghCore.info('Auto update complete, no changes were made.');
-    }
-
-    return isUpdated;
   }
 
   async update(pull: octokit.PullsUpdateResponseData): Promise<boolean> {

--- a/src/router.ts
+++ b/src/router.ts
@@ -24,9 +24,11 @@ export class Router {
       await this.updater.handlePullRequest();
     } else if (eventName === 'push') {
       await this.updater.handlePush();
+    } else if (eventName === 'workflow_run') {
+      await this.updater.handleWorkflowRun();
     } else {
       throw new Error(
-        `Unknown event type '${eventName}', only 'push' and 'pull_request' are supported.`,
+        `Unknown event type '${eventName}', only 'push', 'pull_request' and 'workflow_run' are supported.`,
       );
     }
   }

--- a/test/autoupdate.test.ts
+++ b/test/autoupdate.test.ts
@@ -25,6 +25,19 @@ const dummyEvent = {
   ref: `refs/heads/${branch}`,
   repository: {
     owner: {
+      login: owner,
+    },
+    name: repo,
+  },
+};
+const dummyWorkflowRunPushEvent = {
+  workflow_run: {
+    head_branch: branch,
+    event: 'push',
+    pull_requests: [],
+  },
+  repository: {
+    owner: {
       name: owner,
     },
     name: repo,
@@ -406,6 +419,89 @@ describe('test `handlePush`', () => {
     expect(updated).toEqual(expectedPulls);
     expect(updateSpy).toHaveBeenCalledTimes(expectedPulls);
     expect(scope.isDone()).toEqual(true);
+  });
+});
+
+describe('test `handleWorkflowRun`', () => {
+  const cloneEvent = () =>
+    JSON.parse(JSON.stringify(dummyWorkflowRunPushEvent));
+
+  test('workflow_run event by push event on a non-branch', async () => {
+    const event = cloneEvent();
+    event.workflow_run.head_branch = '';
+
+    const updater = new AutoUpdater(config, event);
+
+    const updateSpy = jest.spyOn(updater, 'update').mockResolvedValue(true);
+
+    const updated = await updater.handleWorkflowRun();
+
+    expect(updated).toEqual(0);
+    expect(updateSpy).toHaveBeenCalledTimes(0);
+  });
+
+  test('workflow_run event by push event on a branch without any PRs', async () => {
+    const updater = new AutoUpdater(config, dummyWorkflowRunPushEvent);
+
+    const updateSpy = jest.spyOn(updater, 'update').mockResolvedValue(true);
+
+    const scope = nock('https://api.github.com:443')
+      .get(
+        `/repos/${owner}/${repo}/pulls?base=${branch}&state=open&sort=updated&direction=desc`,
+      )
+      .reply(200, []);
+
+    const updated = await updater.handleWorkflowRun();
+
+    expect(updated).toEqual(0);
+    expect(updateSpy).toHaveBeenCalledTimes(0);
+    expect(scope.isDone()).toEqual(true);
+  });
+
+  test('workflow_run event by push event on a branch with PRs', async () => {
+    const updater = new AutoUpdater(config, dummyWorkflowRunPushEvent);
+
+    const pullsMock = [];
+    const expectedPulls = 5;
+    for (let i = 0; i < expectedPulls; i++) {
+      pullsMock.push({
+        id: i,
+        number: i,
+      });
+    }
+
+    const updateSpy = jest.spyOn(updater, 'update').mockResolvedValue(true);
+
+    const scope = nock('https://api.github.com:443')
+      .get(
+        `/repos/${owner}/${repo}/pulls?base=${branch}&state=open&sort=updated&direction=desc`,
+      )
+      .reply(200, pullsMock);
+
+    const updated = await updater.handleWorkflowRun();
+
+    expect(updated).toEqual(expectedPulls);
+    expect(updateSpy).toHaveBeenCalledTimes(expectedPulls);
+    expect(scope.isDone()).toEqual(true);
+  });
+
+  test('workflow_run event by pull_request event not supported', async () => {
+    const event = cloneEvent();
+    event.workflow_run.pull_requests = [
+      {
+        url: 'https://api.github.com/repos/github/hello-world/pulls/1',
+        id: 1,
+      },
+    ];
+
+    const updater = new AutoUpdater(config, event);
+
+    const updateSpy = jest.spyOn(updater, 'update').mockResolvedValue(true);
+
+    const updated = await updater.handleWorkflowRun();
+
+    expect(updated).toEqual(0);
+    expect(updateSpy).toHaveBeenCalledTimes(0);
   });
 });
 

--- a/test/autoupdate.test.ts
+++ b/test/autoupdate.test.ts
@@ -487,12 +487,7 @@ describe('test `handleWorkflowRun`', () => {
 
   test('workflow_run event by pull_request event not supported', async () => {
     const event = cloneEvent();
-    event.workflow_run.pull_requests = [
-      {
-        url: 'https://api.github.com/repos/github/hello-world/pulls/1',
-        id: 1,
-      },
-    ];
+    event.workflow_run.event = 'pull_request';
 
     const updater = new AutoUpdater(config, event);
 

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -15,7 +15,7 @@ test('invalid event name', async () => {
 
   const eventName = 'not-a-real-event';
   await expect(router.route(eventName)).rejects.toThrowError(
-    `Unknown event type '${eventName}', only 'push' and 'pull_request' are supported.`,
+    `Unknown event type '${eventName}', only 'push', 'pull_request' and 'workflow_run' are supported.`,
   );
 
   const autoUpdateInstance = (AutoUpdater as jest.Mock).mock.instances[0];
@@ -41,4 +41,14 @@ test('"pull_request" events', async () => {
 
   const autoUpdateInstance = (AutoUpdater as jest.Mock).mock.instances[0];
   expect(autoUpdateInstance.handlePullRequest).toHaveBeenCalledTimes(1);
+});
+
+test('"workflow_run" events', async () => {
+  const router = new Router(config, {});
+  expect(AutoUpdater).toHaveBeenCalledTimes(1);
+
+  await router.route('workflow_run');
+
+  const autoUpdateInstance = (AutoUpdater as jest.Mock).mock.instances[0];
+  expect(autoUpdateInstance.handleWorkflowRun).toHaveBeenCalledTimes(1);
 });


### PR DESCRIPTION
Updates to enhance security around github token handling means that PRs
merged to a target branch by github native dependabot no longer receive
a write access token by default. Instead it is required to have a push
workflow trigger a workflow_run subsequently that is provided with write
access.

To support this add a route and handler function for workflow_run events
that reuses much of the functionality from the push handler by moving
the common capabilities to a shared function.

Includes a check to skip such a workflow if it is triggered via
pull_request events instead until such time as someone can add the
required support using the existing pull_request handler for the common
pieces.

Adds tests following the same pattern for the handlePull function.

Fixes: #137