### PR TITLE
Upgrade octokit types

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@actions/core": "^1.2.6",
     "@actions/github": "^4.0.0",
-    "@octokit/types": "^5.5.0",
+    "@octokit/types": "^6.13.0",
     "@types/node": "^14.14.22",
     "@vercel/ncc": "^0.27.0",
     "typescript": "^4.1.3"

--- a/src/autoupdater.ts
+++ b/src/autoupdater.ts
@@ -3,14 +3,10 @@ import { GitHub } from '@actions/github/lib/utils';
 import * as ghCore from '@actions/core';
 import * as octokit from '@octokit/types';
 import { ConfigLoader } from './config-loader';
+import { Endpoints } from '@octokit/types';
 
-interface MergeOpts {
-  owner: string;
-  repo: string;
-  base: string;
-  head: string;
-  commit_message?: string;
-}
+type pullRequestResponse = Endpoints['GET /repos/{owner}/{repo}/pulls/{pull_number}']['response'];
+type mergeParameters = Endpoints['POST /repos/{owner}/{repo}/merges']['parameters'];
 
 export class AutoUpdater {
   eventData: any;
@@ -51,7 +47,7 @@ export class AutoUpdater {
 
     let pullsPage: octokit.OctokitResponse<any>;
     for await (pullsPage of this.octokit.paginate.iterator(paginatorOpts)) {
-      let pull: octokit.PullsUpdateResponseData;
+      let pull: pullRequestResponse['data'];
       for (pull of pullsPage.data) {
         ghCore.startGroup(`PR-${pull.number}`);
         const isUpdated = await this.update(pull);
@@ -87,7 +83,7 @@ export class AutoUpdater {
     return isUpdated;
   }
 
-  async update(pull: octokit.PullsUpdateResponseData): Promise<boolean> {
+  async update(pull: pullRequestResponse['data']): Promise<boolean> {
     const { ref } = pull.head;
     ghCore.info(`Evaluating pull request #${pull.number}...`);
 
@@ -110,7 +106,7 @@ export class AutoUpdater {
     }
 
     const mergeMsg = this.config.mergeMsg();
-    const mergeOpts: octokit.RequestParameters & MergeOpts = {
+    const mergeOpts: mergeParameters = {
       owner: pull.head.repo.owner.login,
       repo: pull.head.repo.name,
       // We want to merge the base branch into this one.
@@ -135,7 +131,7 @@ export class AutoUpdater {
     return true;
   }
 
-  async prNeedsUpdate(pull: octokit.PullsUpdateResponseData): Promise<boolean> {
+  async prNeedsUpdate(pull: pullRequestResponse['data']): Promise<boolean> {
     if (pull.merged === true) {
       ghCore.warning('Skipping pull request, already merged.');
       return false;
@@ -173,6 +169,10 @@ export class AutoUpdater {
     const excludedLabels = this.config.excludedLabels();
     if (excludedLabels.length > 0) {
       for (const label of pull.labels) {
+        if (label.name === undefined) {
+          ghCore.warning(`Label name is undefined, skipping update.`);
+          return false;
+        }
         if (excludedLabels.includes(label.name)) {
           ghCore.info(
             `Pull request has excluded label '${label.name}', skipping update.`,
@@ -208,6 +208,11 @@ export class AutoUpdater {
       }
 
       for (const label of pull.labels) {
+        if (label.name === undefined) {
+          ghCore.warning(`Label name is undefined, skipping update.`);
+          return false;
+        }
+
         if (labels.includes(label.name)) {
           ghCore.info(
             `Pull request has label '${label.name}' and PR branch is behind base branch.`,
@@ -247,9 +252,7 @@ export class AutoUpdater {
     return true;
   }
 
-  async merge(
-    mergeOpts: octokit.RequestParameters & MergeOpts,
-  ): Promise<boolean> {
+  async merge(mergeOpts: mergeParameters): Promise<boolean> {
     const sleep = (timeMs: number) => {
       return new Promise((resolve) => {
         setTimeout(resolve, timeMs);

--- a/test/autoupdate.test.ts
+++ b/test/autoupdate.test.ts
@@ -9,7 +9,7 @@ import config from '../src/config-loader';
 import { AutoUpdater } from '../src/autoupdater';
 import { Endpoints } from '@octokit/types';
 
-type pullRequestResponse = Endpoints['GET /repos/{owner}/{repo}/pulls/{pull_number}']['response'];
+type PullRequestResponse = Endpoints['GET /repos/{owner}/{repo}/pulls/{pull_number}']['response'];
 
 jest.mock('../src/config-loader');
 
@@ -95,7 +95,7 @@ describe('test `prNeedsUpdate`', () => {
 
     const updater = new AutoUpdater(config, {});
     const needsUpdate = await updater.prNeedsUpdate(
-      (pull as unknown) as pullRequestResponse['data'],
+      (pull as unknown) as PullRequestResponse['data'],
     );
     expect(needsUpdate).toEqual(false);
   });
@@ -108,7 +108,7 @@ describe('test `prNeedsUpdate`', () => {
 
     const updater = new AutoUpdater(config, {});
     const needsUpdate = await updater.prNeedsUpdate(
-      (pull as unknown) as pullRequestResponse['data'],
+      (pull as unknown) as PullRequestResponse['data'],
     );
     expect(needsUpdate).toEqual(false);
   });
@@ -123,7 +123,7 @@ describe('test `prNeedsUpdate`', () => {
     });
     const updater = new AutoUpdater(config, {});
     const needsUpdate = await updater.prNeedsUpdate(
-      (pull as unknown) as pullRequestResponse['data'],
+      (pull as unknown) as PullRequestResponse['data'],
     );
     expect(needsUpdate).toEqual(false);
   });
@@ -137,7 +137,7 @@ describe('test `prNeedsUpdate`', () => {
 
     const updater = new AutoUpdater(config, {});
     const needsUpdate = await updater.prNeedsUpdate(
-      (validPull as unknown) as pullRequestResponse['data'],
+      (validPull as unknown) as PullRequestResponse['data'],
     );
 
     expect(needsUpdate).toEqual(false);
@@ -156,7 +156,7 @@ describe('test `prNeedsUpdate`', () => {
 
     const updater = new AutoUpdater(config, {});
     const needsUpdate = await updater.prNeedsUpdate(
-      (validPull as unknown) as pullRequestResponse['data'],
+      (validPull as unknown) as PullRequestResponse['data'],
     );
 
     expect(needsUpdate).toEqual(true);
@@ -213,7 +213,7 @@ describe('test `prNeedsUpdate`', () => {
 
     const updater = new AutoUpdater(config, {});
     const needsUpdate = await updater.prNeedsUpdate(
-      (validPull as unknown) as pullRequestResponse['data'],
+      (validPull as unknown) as PullRequestResponse['data'],
     );
 
     expect(needsUpdate).toEqual(false);
@@ -259,7 +259,7 @@ describe('test `prNeedsUpdate`', () => {
 
     const updater = new AutoUpdater(config, {});
     const needsUpdate = await updater.prNeedsUpdate(
-      (invalidLabelPull as unknown) as pullRequestResponse['data'],
+      (invalidLabelPull as unknown) as PullRequestResponse['data'],
     );
 
     expect(needsUpdate).toEqual(false);
@@ -271,6 +271,7 @@ describe('test `prNeedsUpdate`', () => {
 
   test('pull request has labels with no name - excluded labels checked', async () => {
     (config.pullRequestFilter as jest.Mock).mockReturnValue('labelled');
+    (config.pullRequestLabels as jest.Mock).mockReturnValue([]);
     (config.excludedLabels as jest.Mock).mockReturnValue(['one', 'two']);
 
     const scope = nock('https://api.github.com:443')
@@ -281,11 +282,13 @@ describe('test `prNeedsUpdate`', () => {
 
     const updater = new AutoUpdater(config, {});
     const needsUpdate = await updater.prNeedsUpdate(
-      (invalidLabelPull as unknown) as pullRequestResponse['data'],
+      (invalidLabelPull as unknown) as PullRequestResponse['data'],
     );
 
     expect(needsUpdate).toEqual(false);
     expect(scope.isDone()).toEqual(true);
+    expect(config.pullRequestFilter).toHaveBeenCalled();
+    expect(config.pullRequestLabels).toHaveBeenCalled();
     expect(config.excludedLabels).toHaveBeenCalled();
   });
 
@@ -302,7 +305,7 @@ describe('test `prNeedsUpdate`', () => {
 
     const updater = new AutoUpdater(config, {});
     const needsUpdate = await updater.prNeedsUpdate(
-      (validPull as unknown) as pullRequestResponse['data'],
+      (validPull as unknown) as PullRequestResponse['data'],
     );
 
     expect(needsUpdate).toEqual(false);
@@ -355,7 +358,7 @@ describe('test `prNeedsUpdate`', () => {
 
     const updater = new AutoUpdater(config, {});
     const needsUpdate = await updater.prNeedsUpdate(
-      (validPull as unknown) as pullRequestResponse['data'],
+      (validPull as unknown) as PullRequestResponse['data'],
     );
 
     expect(needsUpdate).toEqual(true);
@@ -383,7 +386,7 @@ describe('test `prNeedsUpdate`', () => {
 
     const updater = new AutoUpdater(config, {});
     const needsUpdate = await updater.prNeedsUpdate(
-      (validPull as unknown) as pullRequestResponse['data'],
+      (validPull as unknown) as PullRequestResponse['data'],
     );
 
     expect(needsUpdate).toEqual(false);
@@ -405,7 +408,7 @@ describe('test `prNeedsUpdate`', () => {
 
     const updater = new AutoUpdater(config, {});
     const needsUpdate = await updater.prNeedsUpdate(
-      (validPull as unknown) as pullRequestResponse['data'],
+      (validPull as unknown) as PullRequestResponse['data'],
     );
 
     expect(needsUpdate).toEqual(true);

--- a/yarn.lock
+++ b/yarn.lock
@@ -561,6 +561,11 @@
     "@octokit/types" "^5.0.0"
     universal-user-agent "^6.0.0"
 
+"@octokit/openapi-types@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-6.0.0.tgz#7da8d7d5a72d3282c1a3ff9f951c8133a707480d"
+  integrity sha512-CnDdK7ivHkBtJYzWzZm7gEkanA7gKH6a09Eguz7flHw//GacPJLmkHA3f3N++MJmlxD1Fl+mB7B32EEpSCwztQ==
+
 "@octokit/plugin-paginate-rest@^2.2.3":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.4.0.tgz#92f951ddc8a1cd505353fa07650752ca25ed7e93"
@@ -605,6 +610,13 @@
   integrity sha512-UZ1pErDue6bZNjYOotCNveTXArOMZQFG6hKJfOnGnulVCMcVVi7YIIuuR4WfBhjo7zgpmzn/BkPDnUXtNx+PcQ==
   dependencies:
     "@types/node" ">= 8"
+
+"@octokit/types@^6.13.0":
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.13.0.tgz#779e5b7566c8dde68f2f6273861dd2f0409480d0"
+  integrity sha512-W2J9qlVIU11jMwKHUp5/rbVUeErqelCsO5vW5PKNb7wAXQVUz87Rc+imjlEvpvbH8yUb+KHmv8NEjVZdsdpyxA==
+  dependencies:
+    "@octokit/openapi-types" "^6.0.0"
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.1"
@@ -697,12 +709,7 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
-"@types/node@*", "@types/node@>= 8":
-  version "14.11.8"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.11.8.tgz#fe2012f2355e4ce08bca44aeb3abbb21cf88d33f"
-  integrity sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw==
-
-"@types/node@^14.14.22":
+"@types/node@*", "@types/node@>= 8", "@types/node@^14.14.22":
   version "14.14.22"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.22.tgz#0d29f382472c4ccf3bd96ff0ce47daf5b7b84b18"
   integrity sha512-g+f/qj/cNcqKkc3tFqlXOYjrmZA+jNBiDzbP3kH+B+otKFqAdPgVTGP1IeKRdMml/aE69as5S4FqtxAbl+LaMw==


### PR DESCRIPTION
- Redefine the autoupdate types using the octokit 'endpoint' functionality
- Adds a null check for PR label names and test cases