### PR TITLE
Support for the 'schedule' event

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # autoupdate
+
 ![Tests](https://github.com/chinthakagodawita/autoupdate/workflows/Tests/badge.svg?event=push) [![codecov](https://codecov.io/gh/chinthakagodawita/autoupdate/branch/master/graph/badge.svg)](https://codecov.io/gh/chinthakagodawita/autoupdate)
 
 **autoupdate** is a GitHub Action that auto-updates pull requests branches whenever changes land on their destination branch.
 
 ## Usage
+
 Create a file, in your repository, at `.github/workflows/autoupdate.yaml` with the following:
+
 ```yaml
 name: autoupdate
 on:
@@ -22,7 +25,7 @@ jobs:
     steps:
       - uses: docker://chinthakagodawita/autoupdate-action:v1
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
 ```
 
 This will trigger on all pushes and automatically update any pull requests, if changes are pushed to their destination branch.
@@ -30,41 +33,44 @@ This will trigger on all pushes and automatically update any pull requests, if c
 For more information on customising event triggers, see [Github's documentation](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#push-event-push).
 
 The following events are supported:
-* push
-* pull_request
-* workflow_run
+
+- push
+- pull_request
+- workflow_run
 
 ## Configuration
+
 The following configuration options are supported. To change any of these, simply specify it as an `env` value in your workflow file.
 
 All configuration values, except `GITHUB_TOKEN`, are optional.
 
-* `GITHUB_TOKEN`: _autoupdate_ uses this token to perform its operations on your repository. This should generally be set to `"${{ secrets.GITHUB_TOKEN }}"`.
+- `GITHUB_TOKEN`: _autoupdate_ uses this token to perform its operations on your repository. This should generally be set to `"${{ secrets.GITHUB_TOKEN }}"`.
 
   You _may_ want to override this if you want the action to run as a different user than the default actions bot.
 
-* `DRY_RUN`: Enables 'dry run' mode, possible values are `"true"` or `"false"` (default).
+- `DRY_RUN`: Enables 'dry run' mode, possible values are `"true"` or `"false"` (default).
 
   In dry run mode, merge/update operations are logged to the console but not performed. This can be useful if you're testing this action or testing a particular configuration value.
 
-* `PR_FILTER`: Controls how _autoupdate_ chooses which pull requests to operate on. Possible values are:
-  * `"all"` (default): No filter, _autoupdate_ will monitor and update all pull requests.
-  * `"labelled"`: Only monitor PRs with a particular label (or set of labels). Requires the `PR_LABELS` option to be defined to. If `PR_LABELS` is not defined, _autoupdate_ will not monitor any pull requests.
-  * `"protected"`: Only monitor PRs that are raised against [protected branches](https://help.github.com/en/github/administering-a-repository/about-protected-branches).
+- `PR_FILTER`: Controls how _autoupdate_ chooses which pull requests to operate on. Possible values are:
 
-* `PR_LABELS`: Controls which labels _autoupdate_ will look for when monitoring PRs. Only used if `PR_FILTER="labelled"`. This can be either a single label or a comma-separated list of labels.
+  - `"all"` (default): No filter, _autoupdate_ will monitor and update all pull requests.
+  - `"labelled"`: Only monitor PRs with a particular label (or set of labels). Requires the `PR_LABELS` option to be defined to. If `PR_LABELS` is not defined, _autoupdate_ will not monitor any pull requests.
+  - `"protected"`: Only monitor PRs that are raised against [protected branches](https://help.github.com/en/github/administering-a-repository/about-protected-branches).
 
-* `EXCLUDED_LABELS`: Controls which labels _autoupdate_ will ignore when evaluating otherwise-included PRs. This option works with all `PR_FILTER` options and can be either a single label or a comma-separated list of labels.
+- `PR_LABELS`: Controls which labels _autoupdate_ will look for when monitoring PRs. Only used if `PR_FILTER="labelled"`. This can be either a single label or a comma-separated list of labels.
 
-* `MERGE_MSG`: A custom message to use when creating the merge commit from the destination branch to your pull request's branch.
+- `EXCLUDED_LABELS`: Controls which labels _autoupdate_ will ignore when evaluating otherwise-included PRs. This option works with all `PR_FILTER` options and can be either a single label or a comma-separated list of labels.
 
-* `RETRY_COUNT`: The number of times a branch update should be attempted before _autoupdate_ gives up (default: `"5"`).
+- `MERGE_MSG`: A custom message to use when creating the merge commit from the destination branch to your pull request's branch.
 
-* `RETRY_SLEEP`: The amount of time (in milliseconds) that _autoupdate_ should wait between branch update attempts (default: `"300"`).
+- `RETRY_COUNT`: The number of times a branch update should be attempted before _autoupdate_ gives up (default: `"5"`).
 
-* `MERGE_CONFLICT_ACTION`: Controls how _autoupdate_ handles a merge conflict when updating a PR. Possible values are:
-  * `"fail"` (default): _autoupdate_ will report a failure on each PR that has a merge conflict.
-  * `"ignore"`: _autoupdate_ will silently ignore merge conflicts.
+- `RETRY_SLEEP`: The amount of time (in milliseconds) that _autoupdate_ should wait between branch update attempts (default: `"300"`).
+
+- `MERGE_CONFLICT_ACTION`: Controls how _autoupdate_ handles a merge conflict when updating a PR. Possible values are:
+  - `"fail"` (default): _autoupdate_ will report a failure on each PR that has a merge conflict.
+  - `"ignore"`: _autoupdate_ will silently ignore merge conflicts.
 
 Here's an example workflow file with all of the above options specified:
 
@@ -79,15 +85,15 @@ jobs:
     steps:
       - uses: docker://chinthakagodawita/autoupdate-action:v1
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          DRY_RUN: "false"
-          PR_FILTER: "labelled"
-          PR_LABELS: "autoupdate,keep up-to-date,integration"
-          EXCLUDED_LABELS: "dependencies,wontfix"
-          MERGE_MSG: "Branch was auto-updated."
-          RETRY_COUNT: "5"
-          RETRY_SLEEP: "300"
-          MERGE_CONFLICT_ACTION: "fail"
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          DRY_RUN: 'false'
+          PR_FILTER: 'labelled'
+          PR_LABELS: 'autoupdate,keep up-to-date,integration'
+          EXCLUDED_LABELS: 'dependencies,wontfix'
+          MERGE_MSG: 'Branch was auto-updated.'
+          RETRY_COUNT: '5'
+          RETRY_SLEEP: '300'
+          MERGE_CONFLICT_ACTION: 'fail'
 ```
 
 ## Examples
@@ -99,17 +105,19 @@ Here's a screenshot:
 ![An example of autoupdate running on a pull request](/docs/images/autoupdate-example.png)
 
 ## Limitations
-* Branch updates events caused by this action will not trigger any subsequent workflows
-  * [This is a documented limitation](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#about-workflow-events) for all GH actions:
-  > An action in a workflow run can't trigger a new workflow run. For example, if an action pushes code using the repository's GITHUB_TOKEN, a new workflow will not run even when the repository contains a workflow configured to run when push events occur.
-  * There is [an open issue in the Github community forum](https://github.community/t5/GitHub-Actions/Triggering-a-new-workflow-from-another-workflow/td-p/31676) tracking this
+
+- Branch updates events caused by this action will not trigger any subsequent workflows
+  - [This is a documented limitation](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#about-workflow-events) for all GH actions:
+    > An action in a workflow run can't trigger a new workflow run. For example, if an action pushes code using the repository's GITHUB_TOKEN, a new workflow will not run even when the repository contains a workflow configured to run when push events occur.
+  - There is [an open issue in the Github community forum](https://github.community/t5/GitHub-Actions/Triggering-a-new-workflow-from-another-workflow/td-p/31676) tracking this
 
 ## Coming soon
-* Rebase support
-* Label negation support
-* Token support in custom merge messages
-* `schedule` event support
+
+- Rebase support
+- Label negation support
+- Token support in custom merge messages
 
 ## Also see
-* [automerge](https://github.com/pascalgn/automerge-action/) for automatic merging of PRs
-* [autosquash](https://github.com/tibdex/autosquash) for auto-merging with squash support
+
+- [automerge](https://github.com/pascalgn/automerge-action/) for automatic merging of PRs
+- [autosquash](https://github.com/tibdex/autosquash) for auto-merging with squash support

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The following events are supported:
 - push
 - pull_request
 - workflow_run
+- schedule
 
 ## Configuration
 
@@ -85,15 +86,15 @@ jobs:
     steps:
       - uses: docker://chinthakagodawita/autoupdate-action:v1
         env:
-          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-          DRY_RUN: 'false'
-          PR_FILTER: 'labelled'
-          PR_LABELS: 'autoupdate,keep up-to-date,integration'
-          EXCLUDED_LABELS: 'dependencies,wontfix'
-          MERGE_MSG: 'Branch was auto-updated.'
-          RETRY_COUNT: '5'
-          RETRY_SLEEP: '300'
-          MERGE_CONFLICT_ACTION: 'fail'
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          DRY_RUN: "false"
+          PR_FILTER: "labelled"
+          PR_LABELS: "autoupdate,keep up-to-date,integration"
+          EXCLUDED_LABELS: "dependencies,wontfix"
+          MERGE_MSG: "Branch was auto-updated."
+          RETRY_COUNT: "5"
+          RETRY_SLEEP: "300"
+          MERGE_CONFLICT_ACTION: "fail"
 ```
 
 ## Examples
@@ -114,7 +115,6 @@ Here's a screenshot:
 ## Coming soon
 
 - Rebase support
-- Label negation support
 - Token support in custom merge messages
 
 ## Also see

--- a/src/autoupdater.ts
+++ b/src/autoupdater.ts
@@ -124,9 +124,20 @@ export class AutoUpdater {
 
     const baseBranch = ref.replace('refs/heads/', '');
 
+    const owner = repoOwnerName ?? repoOwnerLogin;
+
+    if (!owner) {
+      ghCore.error('Invalid repository owner provided');
+      return 0;
+    }
+    if (!repoName) {
+      ghCore.error('Invalid repository name provided');
+      return 0;
+    }
+
     let updated = 0;
     const paginatorOpts = this.octokit.pulls.list.endpoint.merge({
-      owner: repoOwnerName || repoOwnerLogin,
+      owner: owner,
       repo: repoName,
       base: baseBranch,
       state: 'open',

--- a/src/autoupdater.ts
+++ b/src/autoupdater.ts
@@ -61,27 +61,18 @@ export class AutoUpdater {
   }
 
   async handleSchedule(): Promise<number> {
-    const ref = this.config.getValue('GITHUB_REF');
-    const ownerAndRepo = this.config.getValue('GITHUB_REPOSITORY');
-
-    if (ownerAndRepo === undefined) {
-      ghCore.error('GITHUB_REPOSITORY value is undefined.');
-      return 0;
-    }
-
-    if (ref === undefined) {
-      ghCore.error('GITHUB_REF value is undefined.');
-      return 0;
-    }
+    const ref = this.config.githubRef();
+    const ownerAndRepo = this.config.githubRepository();
 
     const splitRepoName = ownerAndRepo.split('/');
-    const repoOwner = splitRepoName[0];
-    const repoName = splitRepoName[1];
 
-    if (repoOwner === undefined || repoName === undefined) {
+    if (splitRepoName.length !== 2) {
       ghCore.error(`Cannot parse GITHUB_REPOSITORY value ${ownerAndRepo}`);
       return 0;
     }
+
+    const repoOwner = splitRepoName[0];
+    const repoName = splitRepoName[1];
 
     ghCore.info(`Handling schedule event on '${ref}'`);
 

--- a/src/autoupdater.ts
+++ b/src/autoupdater.ts
@@ -64,8 +64,6 @@ export class AutoUpdater {
     const ref = this.config.getValue('GITHUB_REF');
     const ownerAndRepo = this.config.getValue('GITHUB_REPOSITORY');
 
-    ghCore.info('Owner and repo: ' + ownerAndRepo);
-
     if (ownerAndRepo === undefined) {
       ghCore.error('GITHUB_REPOSITORY value is undefined.');
       return 0;
@@ -85,7 +83,7 @@ export class AutoUpdater {
       return 0;
     }
 
-    ghCore.info(`Handling schedule event triggered by 'schedule' on '${ref}'`);
+    ghCore.info(`Handling schedule event on '${ref}'`);
 
     return await this.pulls(ref, repoName, repoOwner);
   }

--- a/src/config-loader.ts
+++ b/src/config-loader.ts
@@ -61,6 +61,14 @@ export class ConfigLoader {
     return this.getValue('MERGE_CONFLICT_ACTION', false, 'fail');
   }
 
+  githubRef(): string {
+    return this.getValue('GITHUB_REF', true, '');
+  }
+
+  githubRepository(): string {
+    return this.getValue('GITHUB_REPOSITORY', true, '');
+  }
+
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   getValue(key: string, required = false, defaultVal?: any): any {
     if (

--- a/src/router.ts
+++ b/src/router.ts
@@ -22,9 +22,11 @@ export class Router {
       await this.updater.handlePush();
     } else if (eventName === 'workflow_run') {
       await this.updater.handleWorkflowRun();
+    } else if (eventName === 'schedule') {
+      await this.updater.handleSchedule();
     } else {
       throw new Error(
-        `Unknown event type '${eventName}', only 'push', 'pull_request' and 'workflow_run' are supported.`,
+        `Unknown event type '${eventName}', only 'push', 'pull_request', 'workflow_run', and 'schedule' are supported.`,
       );
     }
   }

--- a/test/autoupdate.test.ts
+++ b/test/autoupdate.test.ts
@@ -31,6 +31,7 @@ const repo = 'not-a-real-repo';
 const base = 'master';
 const head = 'develop';
 const branch = 'not-a-real-branch';
+
 const dummyPushEvent = createMock<PushEvent>({
   ref: `refs/heads/${branch}`,
   repository: {
@@ -64,6 +65,9 @@ const dummyWorkflowRunPullRequestEvent = createMock<WorkflowRunEvent>({
     name: repo,
   },
 });
+const dummyScheduleEvent = {
+  schedule: '*/5 * * * *',
+};
 const invalidLabelPull = {
   number: 1,
   merged: false,
@@ -510,6 +514,108 @@ describe('test `handlePush`', () => {
     expect(updated).toEqual(expectedPulls);
     expect(updateSpy).toHaveBeenCalledTimes(expectedPulls);
     expect(scope.isDone()).toEqual(true);
+  });
+});
+
+describe('test `handleSchedule`', () => {
+  test('schedule event on a branch with PRs', async () => {
+    jest.spyOn(config, 'getValue').mockImplementation((key) => {
+      if (key === 'GITHUB_REPOSITORY') {
+        return `${owner}/${repo}`;
+      }
+
+      if (key === 'GITHUB_REF') {
+        return `refs/heads/${base}`;
+      }
+    });
+
+    const event = dummyScheduleEvent;
+    const updater = new AutoUpdater(config, (event as unknown) as WebhookEvent);
+
+    const pullsMock = [];
+    const expectedPulls = 5;
+    for (let i = 0; i < expectedPulls; i++) {
+      pullsMock.push({
+        id: i,
+        number: i,
+      });
+    }
+
+    const updateSpy = jest.spyOn(updater, 'update').mockResolvedValue(true);
+
+    const scope = nock('https://api.github.com:443')
+      .get(
+        `/repos/${owner}/${repo}/pulls?base=${base}&state=open&sort=updated&direction=desc`,
+      )
+      .reply(200, pullsMock);
+
+    const updated = await updater.handleSchedule();
+
+    expect(updated).toEqual(expectedPulls);
+    expect(updateSpy).toHaveBeenCalledTimes(expectedPulls);
+    expect(scope.isDone()).toEqual(true);
+  });
+
+  test('schedule event with undefined GITHIB_REPOSITORY env var', async () => {
+    jest.spyOn(config, 'getValue').mockImplementation((key) => {
+      if (key === 'GITHUB_REPOSITORY') {
+        return undefined;
+      }
+
+      if (key === 'GITHUB_REF') {
+        return `refs/heads/${base}`;
+      }
+    });
+
+    const event = dummyScheduleEvent;
+    const updater = new AutoUpdater(config, (event as unknown) as WebhookEvent);
+    const updateSpy = jest.spyOn(updater, 'update').mockResolvedValue(true);
+
+    const updated = await updater.handleSchedule();
+
+    expect(updated).toEqual(0);
+    expect(updateSpy).toHaveBeenCalledTimes(0);
+  });
+
+  test('schedule event with undefined GITHIB_REF env var', async () => {
+    jest.spyOn(config, 'getValue').mockImplementation((key) => {
+      if (key === 'GITHUB_REPOSITORY') {
+        return `${owner}/${repo}`;
+      }
+
+      if (key === 'GITHUB_REF') {
+        return undefined;
+      }
+    });
+
+    const event = dummyScheduleEvent;
+    const updater = new AutoUpdater(config, (event as unknown) as WebhookEvent);
+    const updateSpy = jest.spyOn(updater, 'update').mockResolvedValue(true);
+
+    const updated = await updater.handleSchedule();
+
+    expect(updated).toEqual(0);
+    expect(updateSpy).toHaveBeenCalledTimes(0);
+  });
+
+  test('schedule event with invalid GITHUB_REPOSITORY env var', async () => {
+    jest.spyOn(config, 'getValue').mockImplementation((key) => {
+      if (key === 'GITHUB_REPOSITORY') {
+        return '';
+      }
+      if (key === 'GITHUB_REF') {
+        return `refs/heads/${base}`;
+      }
+    });
+
+    const event = dummyScheduleEvent;
+    const updater = new AutoUpdater(config, (event as unknown) as WebhookEvent);
+    const updateSpy = jest.spyOn(updater, 'update').mockResolvedValue(true);
+
+    const updated = await updater.handleSchedule();
+
+    expect(updated).toEqual(0);
+    expect(updateSpy).toHaveBeenCalledTimes(0);
   });
 });
 

--- a/test/autoupdate.test.ts
+++ b/test/autoupdate.test.ts
@@ -515,6 +515,44 @@ describe('test `handlePush`', () => {
     expect(updateSpy).toHaveBeenCalledTimes(expectedPulls);
     expect(scope.isDone()).toEqual(true);
   });
+
+  test('push event with invalid owner', async () => {
+    const invalidPushEvent = createMock<PushEvent>({
+      ref: `refs/heads/${branch}`,
+      repository: {
+        owner: {
+          login: '',
+        },
+        name: repo,
+      },
+    });
+    const updater = new AutoUpdater(config, invalidPushEvent);
+    const updateSpy = jest.spyOn(updater, 'update').mockResolvedValue(true);
+
+    const updated = await updater.handlePush();
+
+    expect(updated).toEqual(0);
+    expect(updateSpy).toHaveBeenCalledTimes(0);
+  });
+
+  test('push event with invalid repo name', async () => {
+    const invalidPushEvent = createMock<PushEvent>({
+      ref: `refs/heads/${branch}`,
+      repository: {
+        owner: {
+          login: owner,
+        },
+        name: '',
+      },
+    });
+    const updater = new AutoUpdater(config, invalidPushEvent);
+    const updateSpy = jest.spyOn(updater, 'update').mockResolvedValue(true);
+
+    const updated = await updater.handlePush();
+
+    expect(updated).toEqual(0);
+    expect(updateSpy).toHaveBeenCalledTimes(0);
+  });
 });
 
 describe('test `handleSchedule`', () => {
@@ -554,7 +592,7 @@ describe('test `handleSchedule`', () => {
     expect(scope.isDone()).toEqual(true);
   });
 
-  test('schedule event with undefined GITHIB_REPOSITORY env var', async () => {
+  test('schedule event with undefined GITHUB_REPOSITORY env var', async () => {
     jest
       .spyOn(config, 'githubRef')
       .mockImplementation(() => `refs/heads/${base}`);
@@ -565,7 +603,7 @@ describe('test `handleSchedule`', () => {
     await expect(updater.handleSchedule()).rejects.toThrowError();
   });
 
-  test('schedule event with undefined GITHIB_REF env var', async () => {
+  test('schedule event with undefined GITHUB_REF env var', async () => {
     jest
       .spyOn(config, 'githubRepository')
       .mockImplementation(() => `${owner}/${repo}`);

--- a/test/autoupdate.test.ts
+++ b/test/autoupdate.test.ts
@@ -519,15 +519,13 @@ describe('test `handlePush`', () => {
 
 describe('test `handleSchedule`', () => {
   test('schedule event on a branch with PRs', async () => {
-    jest.spyOn(config, 'getValue').mockImplementation((key) => {
-      if (key === 'GITHUB_REPOSITORY') {
-        return `${owner}/${repo}`;
-      }
+    jest
+      .spyOn(config, 'githubRef')
+      .mockImplementation(() => `refs/heads/${base}`);
 
-      if (key === 'GITHUB_REF') {
-        return `refs/heads/${base}`;
-      }
-    });
+    jest
+      .spyOn(config, 'githubRepository')
+      .mockImplementation(() => `${owner}/${repo}`);
 
     const event = dummyScheduleEvent;
     const updater = new AutoUpdater(config, (event as unknown) as WebhookEvent);
@@ -557,56 +555,31 @@ describe('test `handleSchedule`', () => {
   });
 
   test('schedule event with undefined GITHIB_REPOSITORY env var', async () => {
-    jest.spyOn(config, 'getValue').mockImplementation((key) => {
-      if (key === 'GITHUB_REPOSITORY') {
-        return undefined;
-      }
-
-      if (key === 'GITHUB_REF') {
-        return `refs/heads/${base}`;
-      }
-    });
+    jest
+      .spyOn(config, 'githubRef')
+      .mockImplementation(() => `refs/heads/${base}`);
 
     const event = dummyScheduleEvent;
     const updater = new AutoUpdater(config, (event as unknown) as WebhookEvent);
-    const updateSpy = jest.spyOn(updater, 'update').mockResolvedValue(true);
 
-    const updated = await updater.handleSchedule();
-
-    expect(updated).toEqual(0);
-    expect(updateSpy).toHaveBeenCalledTimes(0);
+    await expect(updater.handleSchedule()).rejects.toThrowError();
   });
 
   test('schedule event with undefined GITHIB_REF env var', async () => {
-    jest.spyOn(config, 'getValue').mockImplementation((key) => {
-      if (key === 'GITHUB_REPOSITORY') {
-        return `${owner}/${repo}`;
-      }
-
-      if (key === 'GITHUB_REF') {
-        return undefined;
-      }
-    });
+    jest
+      .spyOn(config, 'githubRepository')
+      .mockImplementation(() => `${owner}/${repo}`);
 
     const event = dummyScheduleEvent;
     const updater = new AutoUpdater(config, (event as unknown) as WebhookEvent);
-    const updateSpy = jest.spyOn(updater, 'update').mockResolvedValue(true);
-
-    const updated = await updater.handleSchedule();
-
-    expect(updated).toEqual(0);
-    expect(updateSpy).toHaveBeenCalledTimes(0);
+    await expect(updater.handleSchedule()).rejects.toThrowError();
   });
 
   test('schedule event with invalid GITHUB_REPOSITORY env var', async () => {
-    jest.spyOn(config, 'getValue').mockImplementation((key) => {
-      if (key === 'GITHUB_REPOSITORY') {
-        return '';
-      }
-      if (key === 'GITHUB_REF') {
-        return `refs/heads/${base}`;
-      }
-    });
+    jest.spyOn(config, 'githubRepository').mockImplementation(() => '');
+    jest
+      .spyOn(config, 'githubRef')
+      .mockImplementation(() => `refs/heads/${base}`);
 
     const event = dummyScheduleEvent;
     const updater = new AutoUpdater(config, (event as unknown) as WebhookEvent);

--- a/test/config-loader.test.ts
+++ b/test/config-loader.test.ts
@@ -71,6 +71,20 @@ const tests = [
     default: 'fail',
     type: 'string',
   },
+  {
+    name: 'githubRef',
+    envVar: 'GITHUB_REF',
+    required: true,
+    default: '',
+    type: 'string',
+  },
+  {
+    name: 'githubRepository',
+    envVar: 'GITHUB_REPOSITORY',
+    required: true,
+    default: '',
+    type: 'string',
+  },
 ];
 
 for (const testDef of tests) {

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -16,7 +16,7 @@ test('invalid event name', async () => {
 
   const eventName = 'not-a-real-event';
   await expect(router.route(eventName)).rejects.toThrowError(
-    `Unknown event type '${eventName}', only 'push', 'pull_request' and 'workflow_run' are supported.`,
+    `Unknown event type '${eventName}', only 'push', 'pull_request', 'workflow_run', and 'schedule' are supported.`,
   );
 
   const autoUpdateInstance = (AutoUpdater as jest.Mock).mock.instances[0];
@@ -52,4 +52,14 @@ test('"workflow_run" events', async () => {
 
   const autoUpdateInstance = (AutoUpdater as jest.Mock).mock.instances[0];
   expect(autoUpdateInstance.handleWorkflowRun).toHaveBeenCalledTimes(1);
+});
+
+test('"schedule" events', async () => {
+  const router = new Router(config, {} as WebhookEvent);
+  expect(AutoUpdater).toHaveBeenCalledTimes(1);
+
+  await router.route('schedule');
+
+  const autoUpdateInstance = (AutoUpdater as jest.Mock).mock.instances[0];
+  expect(autoUpdateInstance.handleSchedule).toHaveBeenCalledTimes(1);
 });


### PR DESCRIPTION
- Adds handling for the schedule event by getting the repo name/owner from the `GITHUB_REPOSITORY` env var and the ref from the `GITHUB_REF` env var
- Manually tested [here](https://github.com/anarast/autoupdate-test/actions/runs/765797693)