### PR TITLE
Bump node and node types versions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,10 +5,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Node.js 14.x
+      - name: Set up Node.js 16.x
         uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 16.x
       - name: Install dependencies
         run: yarn install --dev
       - name: Lint files

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine as builder
+FROM node:16-alpine as builder
 
 RUN mkdir -p /opt/autoupdate/dist
 
@@ -8,7 +8,7 @@ COPY . /opt/autoupdate/
 
 RUN yarn install --frozen-lockfile && yarn run build
 
-FROM node:14-alpine as runner
+FROM node:16-alpine as runner
 
 LABEL com.github.actions.name="Auto-update pull requests with changes from their base branch"
 LABEL com.github.actions.description="A GitHub Action that auto-updates PRs with changes from their base branch"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@actions/github": "^4.0.0",
     "@octokit/types": "^6.14.2",
     "@octokit/webhooks": "^9.0.0",
-    "@types/node": "^14.14.37",
+    "@types/node": "^15.12.2",
     "@vercel/ncc": "^0.28.6",
     "ttypescript": "^1.5.12",
     "typescript": "^4.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -746,10 +746,15 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
-"@types/node@*", "@types/node@>= 8", "@types/node@^14.14.37":
+"@types/node@*", "@types/node@>= 8":
   version "14.14.37"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.37.tgz#a3dd8da4eb84a996c36e331df98d82abd76b516e"
   integrity sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==
+
+"@types/node@^15.12.2":
+  version "15.12.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.12.2.tgz#1f2b42c4be7156ff4a6f914b2fb03d05fa84e38d"
+  integrity sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"


### PR DESCRIPTION
Updates node 14 -> 16, node types 14 -> 15

Manually tested here: https://github.com/anarast/autoupdate-test/runs/2814466016
