### PR TITLE
Add option to filter PRs based on ready state

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ All configuration values, except `GITHUB_TOKEN`, are optional.
 
 - `PR_LABELS`: Controls which labels _autoupdate_ will look for when monitoring PRs. Only used if `PR_FILTER="labelled"`. This can be either a single label or a comma-separated list of labels.
 
+- `PR_READY_STATE`: Controls how _autoupdate_ monitors pull requests based on their current [draft / ready for review](https://help.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) state. Possible values are:
+
+  - `"all"`: (default): No filter, _autoupdate_ will monitor and update pull requests regardless of ready state.
+  - `"ready_for_review"`: Only monitor PRs that are not currently in the draft state.
+  - `"draft"`: Only monitor PRs that are currently in the draft state.
+
 - `EXCLUDED_LABELS`: Controls which labels _autoupdate_ will ignore when evaluating otherwise-included PRs. This option works with all `PR_FILTER` options and can be either a single label or a comma-separated list of labels.
 
 - `MERGE_MSG`: A custom message to use when creating the merge commit from the destination branch to your pull request's branch.

--- a/src/autoupdater.ts
+++ b/src/autoupdater.ts
@@ -331,6 +331,21 @@ export class AutoUpdater {
       return false;
     }
 
+    const readyStateFilter = this.config.pullRequestReadyState();
+    if (readyStateFilter !== 'all') {
+      ghCore.info('Checking PR ready state');
+
+      if (readyStateFilter === 'draft' && !pull.draft) {
+        ghCore.info('Pull request is not draft, skipping update.');
+        return false;
+      }
+
+      if (readyStateFilter === 'ready_for_review' && pull.draft) {
+        ghCore.info('Pull request is draft, skipping update.');
+        return false;
+      }
+    }
+
     ghCore.info('All checks pass and PR branch is behind base branch.');
     return true;
   }

--- a/src/autoupdater.ts
+++ b/src/autoupdater.ts
@@ -265,6 +265,21 @@ export class AutoUpdater {
       }
     }
 
+    const readyStateFilter = this.config.pullRequestReadyState();
+    if (readyStateFilter !== 'all') {
+      ghCore.info('Checking PR ready state');
+
+      if (readyStateFilter === 'draft' && !pull.draft) {
+        ghCore.info('Pull request is not draft, skipping update.');
+        return false;
+      }
+
+      if (readyStateFilter === 'ready_for_review' && pull.draft) {
+        ghCore.info('Pull request is draft, skipping update.');
+        return false;
+      }
+    }
+
     const prFilter = this.config.pullRequestFilter();
 
     ghCore.info(
@@ -329,21 +344,6 @@ export class AutoUpdater {
         'Pull request is not against a protected branch, skipping update.',
       );
       return false;
-    }
-
-    const readyStateFilter = this.config.pullRequestReadyState();
-    if (readyStateFilter !== 'all') {
-      ghCore.info('Checking PR ready state');
-
-      if (readyStateFilter === 'draft' && !pull.draft) {
-        ghCore.info('Pull request is not draft, skipping update.');
-        return false;
-      }
-
-      if (readyStateFilter === 'ready_for_review' && pull.draft) {
-        ghCore.info('Pull request is draft, skipping update.');
-        return false;
-      }
     }
 
     ghCore.info('All checks pass and PR branch is behind base branch.');

--- a/src/autoupdater.ts
+++ b/src/autoupdater.ts
@@ -270,12 +270,12 @@ export class AutoUpdater {
       ghCore.info('Checking PR ready state');
 
       if (readyStateFilter === 'draft' && !pull.draft) {
-        ghCore.info('Pull request is not draft, skipping update.');
+        ghCore.info('PR_READY_STATE=draft and pull request is not draft, skipping update.');
         return false;
       }
 
       if (readyStateFilter === 'ready_for_review' && pull.draft) {
-        ghCore.info('Pull request is draft, skipping update.');
+        ghCore.info('PR_READY_STATE=ready_for_review and pull request is draft, skipping update.');
         return false;
       }
     }

--- a/src/config-loader.ts
+++ b/src/config-loader.ts
@@ -69,6 +69,10 @@ export class ConfigLoader {
     return this.getValue('GITHUB_REPOSITORY', true, '');
   }
 
+  pullRequestReadyState(): string {
+    return this.getValue('PR_READY_STATE', false, 'all');
+  }
+
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   getValue(key: string, required = false, defaultVal?: any): any {
     if (

--- a/test/autoupdate.test.ts
+++ b/test/autoupdate.test.ts
@@ -120,6 +120,7 @@ const validPull = {
       },
     },
   },
+  draft: false,
 };
 const clonePull = () => JSON.parse(JSON.stringify(validPull));
 
@@ -451,6 +452,101 @@ describe('test `prNeedsUpdate`', () => {
     expect(comparePr.isDone()).toEqual(true);
     expect(config.pullRequestFilter).toHaveBeenCalled();
     expect(config.excludedLabels).toHaveBeenCalled();
+  });
+
+  test('pull request ready state is not filtered', async () => {
+    (config.pullRequestReadyState as jest.Mock).mockReturnValue('all');
+    (config.excludedLabels as jest.Mock).mockReturnValue([]);
+
+    const readyScope = nock('https://api.github.com:443')
+      .get(`/repos/${owner}/${repo}/compare/${head}...${base}`)
+      .reply(200, {
+        behind_by: 1,
+      });
+
+    const draftScope = nock('https://api.github.com:443')
+      .get(`/repos/${owner}/${repo}/compare/${head}...${base}`)
+      .reply(200, {
+        behind_by: 1,
+      });
+
+    const updater = new AutoUpdater(config, emptyEvent);
+    const readyPull = clonePull();
+    const draftPull = clonePull();
+    draftPull.draft = true;
+
+    const readyPullNeedsUpdate = await updater.prNeedsUpdate(readyPull);
+    const draftPullNeedsUpdate = await updater.prNeedsUpdate(draftPull);
+
+    expect(readyPullNeedsUpdate).toEqual(true);
+    expect(draftPullNeedsUpdate).toEqual(true);
+    expect(config.pullRequestReadyState).toHaveBeenCalled();
+    expect(readyScope.isDone()).toEqual(true);
+    expect(draftScope.isDone()).toEqual(true);
+  });
+
+  test('pull request is filtered to drafts only', async () => {
+    (config.pullRequestReadyState as jest.Mock).mockReturnValue('draft');
+    (config.excludedLabels as jest.Mock).mockReturnValue([]);
+
+    const readyScope = nock('https://api.github.com:443')
+      .get(`/repos/${owner}/${repo}/compare/${head}...${base}`)
+      .reply(200, {
+        behind_by: 1,
+      });
+
+    const draftScope = nock('https://api.github.com:443')
+      .get(`/repos/${owner}/${repo}/compare/${head}...${base}`)
+      .reply(200, {
+        behind_by: 1,
+      });
+
+    const updater = new AutoUpdater(config, emptyEvent);
+    const readyPull = clonePull();
+    const draftPull = clonePull();
+    draftPull.draft = true;
+
+    const readyPullNeedsUpdate = await updater.prNeedsUpdate(readyPull);
+    const draftPullNeedsUpdate = await updater.prNeedsUpdate(draftPull);
+
+    expect(readyPullNeedsUpdate).toEqual(false);
+    expect(draftPullNeedsUpdate).toEqual(true);
+    expect(config.pullRequestReadyState).toHaveBeenCalled();
+    expect(readyScope.isDone()).toEqual(true);
+    expect(draftScope.isDone()).toEqual(true);
+  });
+
+  test('pull request ready state is filtered to ready PRs only', async () => {
+    (config.pullRequestReadyState as jest.Mock).mockReturnValue(
+      'ready_for_review',
+    );
+    (config.excludedLabels as jest.Mock).mockReturnValue([]);
+
+    const readyScope = nock('https://api.github.com:443')
+      .get(`/repos/${owner}/${repo}/compare/${head}...${base}`)
+      .reply(200, {
+        behind_by: 1,
+      });
+
+    const draftScope = nock('https://api.github.com:443')
+      .get(`/repos/${owner}/${repo}/compare/${head}...${base}`)
+      .reply(200, {
+        behind_by: 1,
+      });
+
+    const updater = new AutoUpdater(config, emptyEvent);
+    const readyPull = clonePull();
+    const draftPull = clonePull();
+    draftPull.draft = true;
+
+    const readyPullNeedsUpdate = await updater.prNeedsUpdate(readyPull);
+    const draftPullNeedsUpdate = await updater.prNeedsUpdate(draftPull);
+
+    expect(readyPullNeedsUpdate).toEqual(true);
+    expect(draftPullNeedsUpdate).toEqual(false);
+    expect(config.pullRequestReadyState).toHaveBeenCalled();
+    expect(readyScope.isDone()).toEqual(true);
+    expect(draftScope.isDone()).toEqual(true);
   });
 });
 

--- a/test/config-loader.test.ts
+++ b/test/config-loader.test.ts
@@ -85,6 +85,13 @@ const tests = [
     default: '',
     type: 'string',
   },
+  {
+    name: 'pullRequestReadyState',
+    envVar: 'PR_READY_STATE',
+    required: false,
+    default: 'all',
+    type: 'string',
+  },
 ];
 
 for (const testDef of tests) {


### PR DESCRIPTION
Implements #176.

b83873d goes against the style of the rest of the tests a little, so if you want me to revert it out and make the tests more linear I can. I just wanted to do a _little_ refactoring of the work I did before I put this up.