### PR TITLE
Handle 'not found' error when comparing base with head

### DIFF
--- a/src/autoupdater.ts
+++ b/src/autoupdater.ts
@@ -172,7 +172,6 @@ export class AutoUpdater {
   }
 
   async update(sourceEventOwner: string, pull: PullRequest): Promise<boolean> {
-    console.log('Updating...............');
     const { ref } = pull.head;
     ghCore.info(`Evaluating pull request #${pull.number}...`);
 
@@ -228,7 +227,6 @@ export class AutoUpdater {
   }
 
   async prNeedsUpdate(pull: PullRequest): Promise<boolean> {
-    console.log('Checking if PR needs update');
     if (pull.merged === true) {
       ghCore.warning('Skipping pull request, already merged.');
       return false;
@@ -263,7 +261,9 @@ export class AutoUpdater {
       }
     } catch (e: unknown) {
       if (e instanceof Error) {
-        `Caught error trying to evaluate PR: ${e.message}`;
+        ghCore.error(
+          `Caught error trying to compare base with head: ${e.message}`,
+        );
       }
       return false;
     }

--- a/test/autoupdate.test.ts
+++ b/test/autoupdate.test.ts
@@ -1038,6 +1038,21 @@ describe('test `merge`', () => {
     }
   });
 
+  test('handles errors from compareCommitsWithBasehead', async () => {
+    (config.retryCount as jest.Mock).mockReturnValue(0);
+    const updater = new AutoUpdater(config, emptyEvent);
+
+    const scope = nock('https://api.github.com:443')
+      .get(`/repos/${owner}/${repo}/compare/${head}...${base}`)
+      .reply(404, {
+        message: 'Not Found',
+      });
+
+    const needsUpdate = await updater.update(owner, <any>validPull);
+    expect(needsUpdate).toEqual(false);
+    expect(scope.isDone()).toEqual(true);
+  });
+
   test('handles fork authorisation errors', async () => {
     (config.retryCount as jest.Mock).mockReturnValue(0);
     const updater = new AutoUpdater(config, emptyEvent);


### PR DESCRIPTION
Fixes #230

- Updates `compareCommits()` (deprecated) to `compareCommitsWithBasehead()`.
- Adds error handling for `compareCommitsWithBasehead()` so that autoupdate will continue evaluating any remaining PRs.