### PR TITLE
Update auto_merge check

### DIFF
--- a/src/autoupdater.ts
+++ b/src/autoupdater.ts
@@ -365,7 +365,7 @@ export class AutoUpdater {
     if (prFilter === 'auto_merge') {
       ghCore.info('Checking if this PR has auto_merge enabled.');
 
-      if (pull.auto_merge === null) {
+      if (pull.auto_merge) {
         ghCore.info(
           'Pull request does not have auto_merge enabled, skipping update.',
         );


### PR DESCRIPTION
We started using the `auto_merge` filter, which is super useful! However, I think its updating every open pull request and not just the ones with `auto_merge` enabled. I'm wondering if it becomes `true`/`false` if the setting is turned on instead of `true`/`null`.

_edit_: Also looks like the docker image might need updating https://registry.hub.docker.com/r/chinthakagodawita/autoupdate-action