### PR TITLE
Add `conflicted` output which indicates whether merge conflicts found or not

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,33 @@ jobs:
           MERGE_CONFLICT_ACTION: "fail"
 ```
 
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| conflicted | 'true' or 'false' which indicates whether merge conflicts found or not |
+
+Here's a small example workflow file with outputs above:
+
+```yaml
+name: autoupdate
+on:
+  push: {}
+jobs:
+  autoupdate:
+    name: autoupdate
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: docker://chinthakagodawita/autoupdate-action:v1
+        id: autoupdate
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          MERGE_CONFLICT_ACTION: "ignore"
+
+      - run: echo 'merge conflicts found!'
+        if: steps.autoupdate.outputs.conflicted
+```
+
 ## Examples
 
 See [chinthakagodawita/autoupdate-test/pulls](https://github.com/chinthakagodawita/autoupdate-test/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc) for a repository where autoupdate is enabled. This is currently configured to only run on PRs that have the `autoupdate` tag added to them.

--- a/src/autoupdater.ts
+++ b/src/autoupdater.ts
@@ -445,20 +445,20 @@ export class AutoUpdater {
             return false;
           }
 
-          // Ignore conflicts if configured to do so.
-          if (
-            e.message === 'Merge conflict' &&
-            mergeConflictAction === 'ignore'
-          ) {
-            ghCore.info('Merge conflict detected, skipping update.');
-
-            return false;
-          }
-
-          // Else, throw an error so we don't continue retrying.
           if (e.message === 'Merge conflict') {
-            ghCore.error('Merge conflict error trying to update branch');
-            throw e;
+            ghCore.setOutput('conflicted', true);
+
+            if (mergeConflictAction === 'ignore') {
+              // Ignore conflicts if configured to do so.
+              ghCore.info('Merge conflict detected, skipping update.');
+              return false;
+            } else {
+              // Else, throw an error so we don't continue retrying.
+              ghCore.error('Merge conflict error trying to update branch');
+              throw e;
+            }
+          } else {
+            ghCore.setOutput('conflicted', false);
           }
 
           ghCore.error(`Caught error trying to update branch: ${e.message}`);


### PR DESCRIPTION
This PR brings `conflicted` output which is useful when we'd use the information in a later step:

```yaml
name: autoupdate
on:
  push: {}
jobs:
  autoupdate:
    name: autoupdate
    runs-on: ubuntu-18.04
    steps:
      - uses: docker://chinthakagodawita/autoupdate-action:v1
        id: autoupdate
        env:
          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
          MERGE_CONFLICT_ACTION: "ignore"

      - run: echo 'merge conflicts found!'
         if: steps.autoupdate.outputs.conflicted
```

We, of course, can use the `failure()` expression, but this output is convenient in case of not wanting to complete an action as a failure.