### PR TITLE
Use tsc instead of ncc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,6 @@ RUN apk add --update --no-cache ca-certificates \
 
 WORKDIR /opt/autoupdate
 
-COPY --from=builder /opt/autoupdate/dist/index.js /opt/autoupdate/index.js
+COPY --from=builder /opt/autoupdate/dist /opt/autoupdate
 
-ENTRYPOINT [ "node", "/opt/autoupdate/index.js" ]
+ENTRYPOINT [ "node", "/opt/autoupdate/bin/cli.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /opt/autoupdate
 
 COPY . /opt/autoupdate/
 
-RUN yarn install --frozen-lockfile && yarn run build
+RUN yarn install --immutable --production=true && yarn run build
 
 FROM node:16-alpine as runner
 
@@ -21,5 +21,6 @@ RUN apk add --update --no-cache ca-certificates \
 WORKDIR /opt/autoupdate
 
 COPY --from=builder /opt/autoupdate/dist /opt/autoupdate
+COPY --from=builder /opt/autoupdate/node_modules /opt/autoupdate/node_modules
 
 ENTRYPOINT [ "node", "/opt/autoupdate/bin/cli.js" ]

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "autoupdate-action": "bin/cli.js"
   },
   "scripts": {
-    "build": "ncc build bin/cli.ts --out dist",
+    "build": "tsc bin/cli.ts --outDir dist",
     "lint": "eslint . && prettier --list-different bin/*.ts src/*.ts test/*.ts",
     "lint:fix": "eslint --fix .",
     "test": "jest",
@@ -23,7 +23,6 @@
     "@octokit/webhooks": "^9.12.0",
     "@octokit/webhooks-definitions": "^3.67.3",
     "@types/node": "^16.10.2",
-    "@vercel/ncc": "^0.28.6",
     "ttypescript": "^1.5.12",
     "typescript": "^4.4.2"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
       {
         "transform": "ts-auto-mock/transformer",
         "cacheBetweenTests": false
-      },
+      }
     ]
   },
   "include": ["src/**/*"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -895,11 +895,6 @@
     "@typescript-eslint/types" "4.31.2"
     eslint-visitor-keys "^2.0.0"
 
-"@vercel/ncc@^0.28.6":
-  version "0.28.6"
-  resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.28.6.tgz#073c0ce8e0269210c0a9f180fb0bf949eecc20e0"
-  integrity sha512-t4BoSSuyK8BZaUE0gV18V6bkFs4st7baumtFGa50dv1tMu2GDBEBF8sUZaKBdKiL6DzJ2D2+XVCwYWWDcQOYdQ==
-
 abab@^2.0.3:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.5.tgz#c0b678fb32d60fc1219c784d6a826fe385aeb79a"


### PR DESCRIPTION
Closes https://github.com/chinthakagodawita/autoupdate/issues/181.

Switches the typescript compiler from `ncc` to `tsc`.

Manually tested [here](https://github.com/anarast/autoupdate-test/runs/4649106089?check_suite_focus=true)