### PR TITLE
Replace `octokit.rest.repos.merge` with `octokit.rest.pulls.updateBranch`

### DIFF
--- a/src/autoupdater.ts
+++ b/src/autoupdater.ts
@@ -17,6 +17,9 @@ type PullRequestResponse =
   octokit.Endpoints['GET /repos/{owner}/{repo}/pulls/{pull_number}']['response'];
 type MergeParameters =
   octokit.Endpoints['POST /repos/{owner}/{repo}/merges']['parameters'];
+type UpdateParameters =
+  octokit.Endpoints['POST /pulls/{owner}/{repo}/updates']['parameters'];
+
 
 type PullRequest =
   | PullRequestResponse['data']
@@ -218,17 +221,11 @@ export class AutoUpdater {
     }
 
     const mergeMsg = this.config.mergeMsg();
-    const mergeOpts: MergeParameters = {
+    const mergeOpts: UpdateParameters = {
       owner: pull.head.repo.owner.login,
       repo: pull.head.repo.name,
-      // We want to merge the base branch into this one.
-      base: headRef,
-      head: baseRef,
+      pull_number: pull.number,
     };
-
-    if (mergeMsg !== null && mergeMsg.length > 0) {
-      mergeOpts.commit_message = mergeMsg;
-    }
 
     try {
       return await this.merge(sourceEventOwner, pull.number, mergeOpts);
@@ -425,7 +422,7 @@ export class AutoUpdater {
 
     const doMerge = async () => {
       const mergeResp: octokit.OctokitResponse<any> =
-        await this.octokit.rest.repos.merge(mergeOpts);
+        await this.octokit.rest.pulls.updateBranch(mergeOpts);
 
       // See https://developer.github.com/v3/repos/merging/#perform-a-merge
       const { status } = mergeResp;

--- a/src/autoupdater.ts
+++ b/src/autoupdater.ts
@@ -15,10 +15,8 @@ import { isRequestError } from './helpers/isRequestError';
 
 type PullRequestResponse =
   octokit.Endpoints['GET /repos/{owner}/{repo}/pulls/{pull_number}']['response'];
-type MergeParameters =
-  octokit.Endpoints['POST /repos/{owner}/{repo}/merges']['parameters'];
 type UpdateParameters =
-  octokit.Endpoints['POST /pulls/{owner}/{repo}/updates']['parameters'];
+  octokit.Endpoints['PUT /repos/{owner}/{repo}/pulls/{pull_number}']['parameters'];
 
 
 type PullRequest =
@@ -410,7 +408,7 @@ export class AutoUpdater {
   async merge(
     sourceEventOwner: string,
     prNumber: number,
-    mergeOpts: MergeParameters,
+    mergeOpts: UpdateParameters,
     // Allows for mocking in tests.
     setOutputFn: SetOutputFn = ghCore.setOutput,
   ): Promise<boolean> {


### PR DESCRIPTION
Autoupdate doesn't trigger `pull_request:synchronize`

This causes actions triggered on `pull_request:synchronize` to hang.
I am not sure how to address this as I have basically no experience with wringing github actions but I was looking into invoking `octokit.rest.pulls.updateBranch` instead of `octokit.rest.repos.merge`,

One side effect is that we can't have custom commit messages as this option is not available via `updateBranch()`

Does this make sense?